### PR TITLE
Use a RockChip HID for UART, not HiSi

### DIFF
--- a/Rk3399Pkg/AcpiTables/Dsdt.asl
+++ b/Rk3399Pkg/AcpiTables/Dsdt.asl
@@ -90,8 +90,8 @@ DefinitionBlock ("DSDT.aml", "DSDT", 2, "RKCP  ", "RK3399  ", 3)
 
         Device (COM1)
         {
-            Name (_HID, "HISI0031")                             // _HID: Hardware ID
-            Name (_CID, "8250dw")                               // _CID: Compatible ID
+            Name (_HID, "RKCP8250")                             // _HID: Hardware ID
+            Name (_CID, Package() {"HISI0031", "8250dw"})       // _CID: Compatible ID
             Name (_ADR, FixedPcdGet64(PcdSerialRegisterBase))   // _ADR: Address
             Name (_CRS, ResourceTemplate ()                     // _CRS: Current Resource Settings
             {


### PR DESCRIPTION
"HISI0031" is an ID specific to HiSilicon's implementation of the Synopsys DesignWare 8250 UART, but is misused by the Linux kernel driver as a generic "8250-like UART" ID. Since HiSilicon doesn't supply RockChip's UART, it's incorrect to use a HiSilicon vendor ID for it.
Correctly identify the RockChip UART as "RKCP8250" (using RockChip's real ACPI vendor ID), and declare it as compatible with HiSilicon's version.